### PR TITLE
Don't override an object that doesn't have a catid

### DIFF
--- a/joomlarrssb.php
+++ b/joomlarrssb.php
@@ -128,6 +128,14 @@ class PlgContentJoomlarrssb extends CMSPlugin
 			return;
 		}
 
+		// Make sure we have a category ID, otherwise, end processing
+		$properties = get_object_vars($article);
+
+		if (!array_key_exists('catid', $properties))
+		{
+			return;
+		}
+
 		// If we're not in the article view, we have to get the full $article object ourselves
 		if ($view == 'featured' || $view == 'category')
 		{
@@ -137,18 +145,10 @@ class PlgContentJoomlarrssb extends CMSPlugin
 			 */
 			$data = $this->loadArticle($article);
 
-			if ((!is_null($data)) && (!isset($article->catid)))
+			if (!is_null($data))
 			{
 				$article = $data;
 			}
-		}
-
-		// Make sure we have a category ID, otherwise, end processing
-		$properties = get_object_vars($article);
-
-		if (!array_key_exists('catid', $properties))
-		{
-			return;
 		}
 
 		// Get the current category


### PR DESCRIPTION
If the onContentAfterTitle event is called from the category blog/list layout
the plugin override category object (Joomla\CMS\Categories\CategoryNode)
with a stdClass. This leads to an exception in the later in the layout the permissions
for 'access-create' is checked.

That was the reason for the revert https://github.com/joomla/joomla-cms/pull/28740 before Joomla 3.9.17 release.
