### PR TITLE
Fixed recursion issue when crawled by YOURLs

### DIFF
--- a/joomlarrssb.php
+++ b/joomlarrssb.php
@@ -318,7 +318,7 @@ class PlgContentJoomlarrssb extends CMSPlugin
 		}
 
 		// Prevent recursion when crawled by YOURLs
-		$agent = @$_SERVER['HTTP_USER_AGENT'];
+		$agent = $this->app->input->server->get('HTTP_USER_AGENT', '', 'cmd')
 
 		// Apply our shortened URL if configured
 		if ($shorten && (stristr($agent, 'YOURLS') === false))

--- a/joomlarrssb.php
+++ b/joomlarrssb.php
@@ -317,8 +317,11 @@ class PlgContentJoomlarrssb extends CMSPlugin
 			return;
 		}
 
+		// Prevent recursion when crawled by YOURLs
+		$agent = @$_SERVER['HTTP_USER_AGENT'];
+
 		// Apply our shortened URL if configured
-		if ($shorten)
+		if ($shorten && (stristr($agent, 'YOURLS') === false))
 		{
 			$data     = [
 				'signature' => $this->params->def('YOURLSAPIKey', '2909bc72e7'),


### PR DESCRIPTION
When the request to shorten url is invoked initially, YOURLs will crawl the site again and this causes a recursion generating duplicated urls on YOURLs.