### PR TITLE
Override twitter icon

### DIFF
--- a/media/css/joomla.css
+++ b/media/css/joomla.css
@@ -30,3 +30,16 @@
         height: 17px
     }
 }
+
+/* Override the twitter colors to use the official color as the background and also use a a11y compliant contrast text color */
+.rrssb-buttons li.rrssb-twitter a {
+	background-color: #1D9BF0;
+}
+
+.rrssb-buttons li.rrssb-twitter a:hover {
+	background-color: #25a3f8;
+}
+
+.rrssb-buttons li.rrssb-twitter a {
+	color: #000333;
+}

--- a/media/css/joomla.css
+++ b/media/css/joomla.css
@@ -40,6 +40,6 @@
 	background-color: #25a3f8;
 }
 
-.rrssb-buttons li.rrssb-twitter a {
+.rrssb-buttons li.rrssb-twitter a .rrssb-text {
 	color: #000333;
 }


### PR DESCRIPTION
Twitter's logo is currently not a11y compliant. This updates the primary background color for the logo to the current official brand color and also adds a dark color for the text. I don't love the text color so would definitely welcome alternatives!